### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot Configuration
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "America/Denver"
+    open-pull-requests-limit: 5
+    rebase-strategy: "auto"
+    assignees:
+      - caleb-wells
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "auto-update"


### PR DESCRIPTION
This pull request introduces a new Dependabot configuration file to automate dependency updates for the project.

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R1-R20): Added a configuration file to enable weekly dependency updates for Python packages (`pip`) on Mondays at 04:00 AM (America/Denver timezone). The configuration limits open pull requests to 5, uses an automatic rebase strategy, assigns updates to `caleb-wells`, and applies the labels "dependencies" and "auto-update" to the pull requests. Commit messages will include the prefix "deps" and the scope of the update.